### PR TITLE
FEAT: adds round-robin writing queue

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -9,7 +9,9 @@ const App: React.FC = () => {
   return (
     <AuthProvider>
       <Toaster position="top-right" duration={3000} theme="light" richColors />
-      <RouterProvider router={router} />
+      <div className="content pb-16">
+        <RouterProvider router={router} />
+      </div>
     </AuthProvider>
   );
 };

--- a/frontend/src/components/Footer.tsx
+++ b/frontend/src/components/Footer.tsx
@@ -2,7 +2,7 @@ import React from "react";
 
 const Footer: React.FC = function Footer() {
   return (
-    <footer className="flex justify-end fixed bottom-0 left-0 w-full mb-6 pt-4 before:absolute before:top-0 before:left-1/2 before:-translate-x-1/2 before:w-screen before:h-px before:bg-primary-border">
+    <footer className="flex justify-end fixed bottom-0 left-0 w-full bg-white z-50 p-4 shadow-md">
       {/* Side Links */}
       <div className="flex gap-4 items-center text-primary-text mr-6">
         <a href="/about" className="text-md hover:text-hover-text">

--- a/frontend/src/components/SessionCard.tsx
+++ b/frontend/src/components/SessionCard.tsx
@@ -62,6 +62,8 @@ const SessionCard: React.FC<SessionCardDataProp> = ({
 }): React.ReactElement => {
   const navigate = useNavigate();
   const contributors = sessionData.project_contributors || [];
+  const currentUser = sessionData.creator;
+  const [showTooltip, setShowTooltip] = React.useState(false);
 
   console.log("Session Data:", sessionData);
   console.log("Creator Data:", sessionData.creator);
@@ -69,6 +71,15 @@ const SessionCard: React.FC<SessionCardDataProp> = ({
   const formattedDate = sessionData.created_at
     ? `Created ${formatDistanceToNow(new Date(sessionData.created_at))} ago`
     : "";
+
+  const isProjectCreator =
+    sessionData.creator_id === sessionData.creator?.auth_id;
+
+  const isUserContributor =
+    currentUser &&
+    contributors.some(
+      (contributor) => contributor.contributor_id === currentUser.auth_id
+    );
 
   return (
     <Card className="w-[350px] min-h-[250px] bg-background-card flex flex-col text-justified">
@@ -79,7 +90,11 @@ const SessionCard: React.FC<SessionCardDataProp> = ({
           </Badge>
           <div className="flex items-center gap-1">
             <Users className="text-secondary-text p-0.5" />
-            <span className="text-secondary-text text-sm">
+            <span
+              className={`text-sm ${
+                isUserContributor ? "text-green-500" : "text-secondary-text"
+              }`}
+            >
               {sessionData.current_contributors_count} /{" "}
               {sessionData.max_contributors}
             </span>
@@ -94,9 +109,6 @@ const SessionCard: React.FC<SessionCardDataProp> = ({
             <span className="text-sm font-medium">
               {sessionData.creator?.user_profile_name || "Anonymous"}
             </span>
-            <span className="text-xs text-secondary-text italic">
-              {formattedDate}
-            </span>
           </div>
         </div>
       </CardHeader>
@@ -106,41 +118,26 @@ const SessionCard: React.FC<SessionCardDataProp> = ({
         </CardDescription>
       </div>
       <CardFooter className="flex-none p-4 w-full">
-        {contributors.length > 0 && (
-          <div className="flex flex-col w-full gap-2">
-            <div className="flex items-center gap-2">
-              <span className="text-sm text-secondary-text">Contributors:</span>
-              <div className="flex -space-x-2 overflow-hidden">
-                {contributors.map((pc) => (
-                  <Avatar
-                    key={pc.contributor_id}
-                    className="h-6 w-6 border-2 border-background"
-                  >
-                    <AvatarImage src={pc.contributor?.avatar_url} />
-                    <AvatarFallback>
-                      {pc.contributor?.user_profile_name?.[0]?.toUpperCase() ||
-                        "?"}
-                    </AvatarFallback>
-                  </Avatar>
-                ))}
-              </div>
-            </div>
-            <Button
-              className="bg-primary-button hover:bg-primary-button-hover w-full cursor-pointer"
-              onClick={() => navigate(`/writing/${sessionData.id}`)}
-            >
-              View Session
-            </Button>
-          </div>
-        )}
-        {!contributors.length && (
+        <div className="flex flex-col w-full gap-2">
           <Button
-            className="bg-primary-button hover:bg-primary-button-hover w-full cursor-pointer"
+            className="bg-primary-button hover:bg-primary-button-hover w-full cursor-pointer relative"
             onClick={() => navigate(`/writing/${sessionData.id}`)}
+            onMouseEnter={() => setShowTooltip(true)}
+            onMouseLeave={() => setShowTooltip(false)}
           >
             View Session
+            {showTooltip && (
+              <span className="absolute top-full mt-1 text-xs bg-gray-700 text-white p-1 rounded">
+                Joined
+              </span>
+            )}
           </Button>
-        )}
+          <div className="mx-4 mt-2">
+            <span className="text-xs text-secondary-text italic">
+              {formattedDate}
+            </span>
+          </div>
+        </div>
       </CardFooter>
     </Card>
   );

--- a/frontend/src/components/auth/AuthCallback.tsx
+++ b/frontend/src/components/auth/AuthCallback.tsx
@@ -1,4 +1,6 @@
 // src/components/auth/AuthCallback.tsx
+// handling for Google login routing 
+
 import { useEffect } from "react";
 import { useNavigate } from "react-router-dom";
 import { supabase } from "@/utils/supabase";
@@ -7,7 +9,7 @@ const AuthCallback = () => {
   const navigate = useNavigate();
 
   useEffect(() => {
-    // This will handle the OAuth redirect
+    // This will eventually handle the OAuth redirect
     const handleAuthStateChange = async () => {
       try {
         // Get the current session

--- a/frontend/src/components/navigation_pages/OpenSessionsPage.tsx
+++ b/frontend/src/components/navigation_pages/OpenSessionsPage.tsx
@@ -3,7 +3,7 @@ import GenreFilter from "../GenreFilter";
 import SearchBar from "../SearchBar";
 import SessionCard, { SessionCardSkeleton } from "../SessionCard";
 import { Button } from "@/components/ui/button";
-import { useNavigate } from "react-router-dom";
+import { useNavigate, useLocation } from "react-router-dom";
 import { ProjectsData } from "@/types/global";
 import { BookPlus } from "lucide-react";
 import { getSessions } from "@/utils/supabase";
@@ -16,7 +16,9 @@ const OpenSessionsPage: React.FC = () => {
   const [error, setError] = useState<string | null>(null);
   const [isLoading, setIsLoading] = useState(true);
   const navigate = useNavigate();
+  const location = useLocation();
   const { isAuthenticated } = useAuth();
+  const [lastFocusTime, setLastFocusTime] = useState<number>(Date.now());
 
   const handleCreateSession = () => {
     if (!isAuthenticated) {
@@ -30,6 +32,7 @@ const OpenSessionsPage: React.FC = () => {
   const handleFetchAllSessions = async () => {
     try {
       setIsLoading(true);
+      console.log("Fetching all sessions with fresh contributor counts...");
       const allSessionsData = await getSessions();
 
       if (!allSessionsData) {
@@ -46,30 +49,72 @@ const OpenSessionsPage: React.FC = () => {
     }
   };
 
-  // useEffect to fetch allSessions once
+  // useEffect to fetch allSessions once on mount
   useEffect(() => {
     handleFetchAllSessions();
+
+    // Check if we need to refresh due to joining a project
+    const shouldRefresh = sessionStorage.getItem("refreshSessions");
+    if (shouldRefresh === "true") {
+      // Clear the flag
+      sessionStorage.removeItem("refreshSessions");
+      // Set a small delay to ensure the DB has been updated
+      setTimeout(() => {
+        handleFetchAllSessions();
+      }, 500);
+    }
   }, []);
+
+  // Refresh data when the component regains focus (user returns from another page)
+  useEffect(() => {
+    const handleFocus = () => {
+      // Always refresh when the page gains focus - this ensures contributor counts are up-to-date
+      console.log("Window gained focus, refreshing sessions data");
+      handleFetchAllSessions();
+      setLastFocusTime(Date.now());
+    };
+
+    // Add event listener for when the window regains focus
+    window.addEventListener("focus", handleFocus);
+
+    // Also refresh when location changes (user navigates back to this page)
+    handleFocus();
+
+    return () => {
+      window.removeEventListener("focus", handleFocus);
+    };
+  }, [location.pathname]);
 
   // handler to change assign filters
   const handleGenreFilter = (genre: string = "All") => setGenreFilter(genre);
   const handleSearch = (query: string) => setSearchQuery(query);
 
   // Make filteredSessions[] based on both searchQuery and genreFilter
-  const filteredSessions = allSessions?.filter((session) => {
-    const matchesGenre =
-      genreFilter === "All" || session.project_genre === genreFilter;
-    const words = searchQuery.toLowerCase().split(" ");
-    const matchesSearch =
-      searchQuery.trim() === "" ||
-      words.some((word) => session.title.toLowerCase().includes(word));
-    return matchesGenre && matchesSearch;
-  });
+  const filteredSessions = allSessions
+    ?.filter((session) => {
+      const matchesGenre =
+        genreFilter === "All" || session.project_genre === genreFilter;
+      const words = searchQuery.toLowerCase().split(" ");
+      const matchesSearch =
+        searchQuery.trim() === "" ||
+        words.some((word) => session.title.toLowerCase().includes(word));
+      return matchesGenre && matchesSearch;
+    })
+    .sort(
+      (a, b) =>
+        new Date(b.created_at).getTime() - new Date(a.created_at).getTime()
+    );
 
   const renderSkeletons = () => {
     return Array(6)
       .fill(0)
       .map((_, index) => <SessionCardSkeleton key={index} />);
+  };
+
+  // Add a refresh button to manually refresh sessions
+  const handleManualRefresh = () => {
+    handleFetchAllSessions();
+    setLastFocusTime(Date.now());
   };
 
   return (
@@ -85,6 +130,13 @@ const OpenSessionsPage: React.FC = () => {
         </div>
 
         <div className="flex gap-3">
+          <Button
+            variant="outline"
+            onClick={handleManualRefresh}
+            disabled={isLoading}
+          >
+            {isLoading ? "Refreshing..." : "Refresh"}
+          </Button>
           <SearchBar onSearch={handleSearch} />
           <Button
             className="bg-amber-800 hover:bg-amber-700 cursor-pointer"
@@ -102,19 +154,23 @@ const OpenSessionsPage: React.FC = () => {
 
       {error && <div className="text-red-500 mb-4">Error: {error}</div>}
 
-      <section className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
-        {isLoading ? (
-          renderSkeletons()
-        ) : filteredSessions && filteredSessions.length > 0 ? (
-          filteredSessions.map((session) => (
-            <SessionCard key={session.id} sessionData={session} />
-          ))
-        ) : (
-          <p className="text-center text-gray-500">
-            {error ? "Failed to load sessions" : "No sessions found."}
-          </p>
-        )}
-      </section>
+      {/* TODO: Add pagination */}
+      {/* Sort by newest added */}
+      <div className="content pb-16">
+        <section className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
+          {isLoading ? (
+            renderSkeletons()
+          ) : filteredSessions && filteredSessions.length > 0 ? (
+            filteredSessions.map((session) => (
+              <SessionCard key={session.id} sessionData={session} />
+            ))
+          ) : (
+            <p className="text-center text-gray-500">
+              {error ? "Failed to load sessions" : "No sessions found."}
+            </p>
+          )}
+        </section>
+      </div>
     </main>
   );
 };

--- a/frontend/src/components/navigation_pages/OpenSessionsPage.tsx
+++ b/frontend/src/components/navigation_pages/OpenSessionsPage.tsx
@@ -20,6 +20,7 @@ const OpenSessionsPage: React.FC = () => {
   const { isAuthenticated } = useAuth();
   const [lastFocusTime, setLastFocusTime] = useState<number>(Date.now());
 
+  // entry handling 
   const handleCreateSession = () => {
     if (!isAuthenticated) {
       navigate("/login");
@@ -29,6 +30,8 @@ const OpenSessionsPage: React.FC = () => {
   };
 
   // getAllSessions
+  // this gets all sessions (open projects) for display on the main page
+  
   const handleFetchAllSessions = async () => {
     try {
       setIsLoading(true);
@@ -58,7 +61,7 @@ const OpenSessionsPage: React.FC = () => {
     if (shouldRefresh === "true") {
       // Clear the flag
       sessionStorage.removeItem("refreshSessions");
-      // Set a small delay to ensure the DB has been updated
+      // Set a small delay to ensure the DB has been updated otherwise stuff breaks
       setTimeout(() => {
         handleFetchAllSessions();
       }, 500);
@@ -69,15 +72,16 @@ const OpenSessionsPage: React.FC = () => {
   useEffect(() => {
     const handleFocus = () => {
       // Always refresh when the page gains focus - this ensures contributor counts are up-to-date
+      // Previous behaviour was that the contributor counts would never update even though the backend was updating appropriately 
       console.log("Window gained focus, refreshing sessions data");
       handleFetchAllSessions();
       setLastFocusTime(Date.now());
     };
 
-    // Add event listener for when the window regains focus
+    // Adds event listener for when the window regains focus
     window.addEventListener("focus", handleFocus);
 
-    // Also refresh when location changes (user navigates back to this page)
+    // Redunancy handling - refresh when location changes (user navigates back to this page)
     handleFocus();
 
     return () => {
@@ -105,13 +109,15 @@ const OpenSessionsPage: React.FC = () => {
         new Date(b.created_at).getTime() - new Date(a.created_at).getTime()
     );
 
+  // loading placeholders 
   const renderSkeletons = () => {
     return Array(6)
       .fill(0)
       .map((_, index) => <SessionCardSkeleton key={index} />);
   };
 
-  // Add a refresh button to manually refresh sessions
+  // Adds a refresh button to manually refresh sessions
+  // TODO: this may be no longer needed 
   const handleManualRefresh = () => {
     handleFetchAllSessions();
     setLastFocusTime(Date.now());

--- a/frontend/src/components/navigation_pages/Profile.tsx
+++ b/frontend/src/components/navigation_pages/Profile.tsx
@@ -1,4 +1,5 @@
-// placeholder for profile / settings page
+// placeholder for profile page
+// settings page has been moved to its own component
 
 const Profile: React.FC = () => {
   return <div>Profile</div>;

--- a/frontend/src/components/navigation_pages/ProjectsPage.tsx
+++ b/frontend/src/components/navigation_pages/ProjectsPage.tsx
@@ -13,7 +13,7 @@ const ProjectsPage: React.FC = () => {
   // getAllProjects
   const handleFetchAllProjects = async () => {
     const allProjectsData = await getProjects();
-
+    console.log("Fetched projects:", allProjectsData); // verbose debugging output
     setAllProjects(allProjectsData || []);
   };
 
@@ -38,33 +38,33 @@ const ProjectsPage: React.FC = () => {
   });
 
   return (
-    <main className='container mx-auto px-4 py-8'>
-      <header className='flex justify-between'>
-        <div className='mb-8 text-left'>
-          <h1 className='text-3xl font-bold text-primary-text'>
+    <main className="container mx-auto px-4 py-8">
+      <header className="flex justify-between">
+        <div className="mb-8 text-left">
+          <h1 className="text-3xl font-bold text-primary-text">
             Completed Stories
           </h1>
-          <p className='text-secondary-text mt-2'>
+          <p className="text-secondary-text mt-2">
             Browse and read collaborative stories created by our community
           </p>
         </div>
 
-        <div className='flex gap-3'>
+        <div className="flex gap-3">
           <SearchBar onSearch={handleSearch} />
         </div>
       </header>
 
-      <nav className='my-6'>
+      <nav className="my-6">
         <GenreFilter onSelect={handleGenreFilter}></GenreFilter>
       </nav>
 
-      <div className='grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6'>
+      <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
         {filteredProjects.length > 0 ? (
           filteredProjects.map((project) => (
             <ProjectCard key={project.id} projectData={project} />
           ))
         ) : (
-          <p className='text-center text-gray-500'>No Stories Found.</p>
+          <p className="text-center text-gray-500">No Stories Found.</p>
         )}
       </div>
     </main>

--- a/frontend/src/components/routing/router.tsx
+++ b/frontend/src/components/routing/router.tsx
@@ -1,5 +1,6 @@
-import React from "react";
+import React, { useState, useEffect } from "react";
 import { createBrowserRouter, Navigate } from "react-router-dom";
+import { supabase } from "@/utils/supabase";
 import LoginPage from "../auth/LoginPage";
 import RegisterPage from "../auth/RegisterPage";
 import WritingEditor from "../writing_pages/WritingEditor";
@@ -38,6 +39,23 @@ const ProtectedRoute: React.FC<{ element: React.ReactNode }> = ({
   element,
 }) => {
   const { isAuthenticated } = useAuth();
+  const [isLoading, setIsLoading] = useState(true);
+
+  useEffect(() => {
+    // Check for session on mount
+    supabase.auth.getSession().then(({ data: { session } }) => {
+      setIsLoading(false);
+    });
+  }, []);
+
+  if (isLoading) {
+    return (
+      <div className="flex items-center justify-center h-screen">
+        <p className="text-xl text-primary-text">Loading...</p>
+      </div>
+    );
+  }
+
   return isAuthenticated ? element : <Navigate to="/login" replace />;
 };
 

--- a/frontend/src/components/writing_pages/WritingEditor.tsx
+++ b/frontend/src/components/writing_pages/WritingEditor.tsx
@@ -10,17 +10,18 @@ import { toast } from "sonner";
 import { Button } from "@/components/ui/button";
 
 import { Textarea } from "@/components/ui/textarea";
-import {
-  Card,
-  CardContent,
-  CardHeader,
-  CardTitle,
-} from "@/components/ui/card";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 
 import { Loader2 } from "lucide-react";
-import { supabase, getCurrentUser } from "../../utils/supabase";
+import {
+  supabase,
+  getCurrentUser,
+  getProjectContributors,
+} from "../../utils/supabase";
 import SnippetSkeleton from "../SnippetSkeleton";
 import { Skeleton } from "@/components/ui/skeleton";
+import { PenTool, Crown } from "lucide-react";
+import { Avatar, AvatarImage, AvatarFallback } from "@/components/ui/avatar";
 
 // Basic interfaces for our data
 interface Project {
@@ -32,13 +33,6 @@ interface Project {
   is_completed: boolean;
 }
 
-// interface ProjectContributor {
-//   id: string;
-//   user_id: string;
-//   current_writer: boolean;
-//   user_made_contribution: boolean;
-// }
-
 interface ProjectSnippet {
   content: string;
   creator_id: string;
@@ -47,6 +41,23 @@ interface ProjectSnippet {
   creator?: {
     user_profile_name: string;
   };
+}
+
+// Interface for contributor (imported from supabase utils)
+interface Contributor {
+  id: string;
+  user_id: string;
+  project_id: string;
+  user_made_contribution: boolean;
+  current_writer: boolean;
+  joined_at?: string;
+  last_contribution_at?: string;
+  user?: {
+    id: string;
+    user_profile_name: string;
+    avatar_url?: string;
+  };
+  user_is_project_creator: boolean;
 }
 
 const WritingEditor: React.FC = () => {
@@ -66,6 +77,50 @@ const WritingEditor: React.FC = () => {
   const [isLoading, setIsLoading] = useState(true);
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [isRefreshing, setIsRefreshing] = useState(false);
+  const [contributors, setContributors] = useState<Contributor[]>([]);
+  const [loadingContributors, setLoadingContributors] = useState(false);
+  const [isProjectCreator, setIsProjectCreator] = useState(false);
+
+  // Function to fetch contributors
+  const fetchContributors = async () => {
+    if (!projectId) return;
+
+    setLoadingContributors(true);
+    try {
+      console.log("Fetching contributors for project:", projectId);
+      const contributorsData = await getProjectContributors(projectId);
+
+      // Debug log to check the current_writer status
+      console.log("Contributors data received:", contributorsData);
+
+      // Explicitly check if anyone has current_writer set to true
+      const currentWriter = contributorsData.find(
+        (c) => c.current_writer === true
+      );
+      console.log(
+        "Current writer:",
+        currentWriter?.user?.user_profile_name || "None"
+      );
+
+      setContributors(contributorsData);
+
+      // If we're one of the contributors, update our status
+      if (userData?.auth_id) {
+        const myStatus = contributorsData.find(
+          (c) => c.user_id === userData.auth_id
+        );
+        if (myStatus) {
+          console.log("My contributor status:", myStatus);
+          setIsMyTurn(myStatus.current_writer || false);
+          setIsProjectCreator(myStatus.user_is_project_creator || false);
+        }
+      }
+    } catch (error) {
+      console.error("Failed to load contributors:", error);
+    } finally {
+      setLoadingContributors(false);
+    }
+  };
 
   // Function to fetch snippets
   const fetchSnippets = async () => {
@@ -120,16 +175,22 @@ const WritingEditor: React.FC = () => {
         setProject(projectData);
 
         // Check if user is a contributor
-        const { data: contributorData } =
-          await supabase
-            .from("project_contributors")
-            .select("*")
-            .eq("project_id", projectId)
-            .eq("user_id", user.id)
-            .single();
+        const { data: contributorData } = await supabase
+          .from("project_contributors")
+          .select("*, user:user_id(*)")
+          .eq("project_id", projectId)
+          .eq("user_id", user.id)
+          .single();
 
-        setIsContributor(!!contributorData);
-        setIsMyTurn(contributorData?.current_writer || false);
+        setIsContributor(!!contributorData); // force convert to a boolean value
+        setIsMyTurn(contributorData?.current_writer || false); // if user is not current_writer, its not their turn to write
+        setIsProjectCreator(contributorData?.user_is_project_creator || false); // set project creator status
+
+        // Fetch project contributors
+        await fetchContributors();
+
+        // Check if the project has a valid current writer
+        await checkAndFixCurrentWriter();
 
         // Fetch previous snippets
         await fetchSnippets();
@@ -142,6 +203,58 @@ const WritingEditor: React.FC = () => {
 
     fetchProjectData();
   }, [projectId, navigate]);
+
+  // Helper function to check if there's a current writer and fix if not
+  const checkAndFixCurrentWriter = async () => {
+    try {
+      // Get all contributors
+      const { data: allContributors, error } = await supabase
+        .from("project_contributors")
+        .select("*")
+        .eq("project_id", projectId);
+
+      if (error) {
+        console.error("Error checking for current writer:", error);
+        return;
+      }
+
+      // Check if any contributor has current_writer set to true
+      const hasCurrentWriter =
+        allContributors &&
+        allContributors.some(
+          (contributor) => contributor.current_writer === true
+        );
+
+      console.log(`Project has a current writer: ${hasCurrentWriter}`);
+
+      // If no one is set as current writer, assign someone
+      if (!hasCurrentWriter && allContributors && allContributors.length > 0) {
+        console.log("No current writer found, assigning one...");
+
+        // Get the first contributor by join date
+        const firstContributor = allContributors.sort(
+          (a, b) =>
+            new Date(a.joined_at).getTime() - new Date(b.joined_at).getTime()
+        )[0];
+
+        // Update this contributor to be current writer
+        const { error: updateError } = await supabase
+          .from("project_contributors")
+          .update({ current_writer: true })
+          .eq("id", firstContributor.id);
+
+        if (updateError) {
+          console.error("Error assigning new writer:", updateError);
+        } else {
+          console.log(`Assigned ${firstContributor.user_id} as current writer`);
+          // Refresh the contributors list
+          await fetchContributors();
+        }
+      }
+    } catch (err) {
+      console.error("Error in checkAndFixCurrentWriter:", err);
+    }
+  };
 
   // Handle word count
   const handleContentChange = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
@@ -156,6 +269,28 @@ const WritingEditor: React.FC = () => {
       const user = await getCurrentUser();
       if (!user) {
         toast.error("Please log in to join this project");
+        return;
+      }
+
+      // Check if user is already a contributor
+      const { data: existingContributor, error: existingContributorError } =
+        await supabase
+          .from("project_contributors")
+          .select("id")
+          .eq("project_id", projectId)
+          .eq("user_id", user.id);
+
+      // Handle checking for existing contributor more robustly
+      if (existingContributorError) {
+        console.error(
+          "Error checking existing contributor:",
+          existingContributorError
+        );
+        // Continue instead of throwing, as this might be a "not found" error which is expected
+      }
+
+      if (existingContributor && existingContributor.length > 0) {
+        toast.error("You've already joined this project");
         return;
       }
 
@@ -177,29 +312,60 @@ const WritingEditor: React.FC = () => {
       }
 
       // Check if there are any current writers
-      const { data: currentWriters, } = await supabase
-        .from("project_contributors")
-        .select("*")
-        .eq("project_id", projectId)
-        .eq("current_writer", true);
+      const { data: currentWriters, error: currentWritersError } =
+        await supabase
+          .from("project_contributors")
+          .select("*")
+          .eq("project_id", projectId)
+          .eq("current_writer", true);
+
+      if (currentWritersError) {
+        console.error("Error checking current writers:", currentWritersError);
+      }
 
       // If no current writers or error fetching (meaning no results), this user should be the writer
       const shouldBeCurrentWriter =
         !currentWriters || currentWriters.length === 0;
 
-      // Insert new contributor
-      // const { data: newContributor, error } = await supabase
-      //   .from("project_contributors")
-      //   .insert({
-      //     project_id: projectId,
-      //     user_id: user.id,
-      //     joined_at: new Date().toISOString(),
-      //     current_writer: shouldBeCurrentWriter,
-      //     user_made_contribution: false,
-      //   })
-      //   .select();
+      // Check if this user is the project creator
+      const { data: projectData } = await supabase
+        .from("projects")
+        .select("creator_id")
+        .eq("id", projectId)
+        .single();
 
-      // if (error) throw error;
+      const isProjectCreator = projectData?.creator_id === user.id;
+
+      // Insert new contributor with all required fields
+      const newContributorData = {
+        project_id: projectId,
+        user_id: user.id,
+        joined_at: new Date().toISOString(),
+        current_writer: shouldBeCurrentWriter,
+        user_made_contribution: false,
+        user_is_project_creator: isProjectCreator,
+        // Adding a default value for last_contribution_at to prevent null issues
+        last_contribution_at: new Date().toISOString(),
+      };
+
+      // Insert with more detailed error handling
+      const { data: newContributor, error } = await supabase
+        .from("project_contributors")
+        .insert(newContributorData)
+        .select();
+
+      if (error) {
+        console.error("Failed to insert new contributor:", error);
+
+        // If we get a 406 error, it might be missing fields or a constraint violation
+        if (error.code === "406" || error.code === "23502") {
+          // 23502 is PostgreSQL's not-null violation code
+          toast.error("Failed to join project: Missing required information");
+        } else {
+          toast.error(`Failed to join project: ${error.message}`);
+        }
+        return;
+      }
 
       // Update the project's current_contributors_count
       const { error: updateError } = await supabase
@@ -210,10 +376,20 @@ const WritingEditor: React.FC = () => {
         })
         .eq("id", projectId);
 
-      if (updateError) throw updateError;
+      if (updateError) {
+        console.error(
+          "Failed to update project contributor count:",
+          updateError
+        );
+        // Continue execution even if this fails
+      }
+
+      // Set a flag in sessionStorage to signal to the sessions page that data should be refreshed
+      sessionStorage.setItem("refreshSessions", "true");
 
       setIsContributor(true);
       setIsMyTurn(shouldBeCurrentWriter);
+      setIsProjectCreator(isProjectCreator);
 
       if (shouldBeCurrentWriter) {
         toast.success(
@@ -224,6 +400,9 @@ const WritingEditor: React.FC = () => {
           "Successfully joined the project! Waiting for your turn..."
         );
       }
+
+      // Refresh the contributors list
+      await fetchContributors();
 
       // Refresh the snippets list
       await fetchSnippets();
@@ -238,23 +417,98 @@ const WritingEditor: React.FC = () => {
       if (refreshedProject) {
         setProject(refreshedProject);
       }
-    } catch (error) {
-      toast.error("Failed to join project");
+    } catch (error: any) {
+      console.error("Join project error:", error);
+      toast.error(
+        `Failed to join project: ${error.message || "Unknown error"}`
+      );
     }
   };
 
   // Leave project
   const handleLeave = async () => {
-    try {
-      if (!userData?.auth_id) return;
+    // Add confirmation dialog
+    if (
+      !window.confirm(
+        "Are you sure you want to leave this project? You'll lose your spot in the writing queue."
+      )
+    ) {
+      return;
+    }
 
+    try {
+      if (!userData?.auth_id) {
+        toast.error("User data not available. Please try again.");
+        return;
+      }
+
+      // Check if this user is the current writer
+      const { data: contributorData, error: contributorError } = await supabase
+        .from("project_contributors")
+        .select("current_writer")
+        .eq("project_id", projectId)
+        .eq("user_id", userData.auth_id)
+        .single();
+
+      if (contributorError) {
+        console.error("Error checking writer status:", contributorError);
+      }
+
+      const isCurrentWriter = contributorData?.current_writer || false;
+
+      // Before deleting, fetch all contributors to find the next writer
+      let nextWriterId = null;
+
+      if (isCurrentWriter) {
+        // Get all contributors ordered by join date
+        const { data: allContributors } = await supabase
+          .from("project_contributors")
+          .select("*")
+          .eq("project_id", projectId)
+          .order("joined_at", { ascending: true });
+
+        if (allContributors && allContributors.length > 1) {
+          // Find the current user's index
+          const currentUserIndex = allContributors.findIndex(
+            (contributor) => contributor.user_id === userData.auth_id
+          );
+
+          // Find the next user in rotation, or the first if current user is last
+          let nextUserIndex = (currentUserIndex + 1) % allContributors.length;
+
+          // Make sure we're not selecting the current user
+          if (allContributors[nextUserIndex].user_id === userData.auth_id) {
+            nextUserIndex = (nextUserIndex + 1) % allContributors.length;
+          }
+
+          nextWriterId = allContributors[nextUserIndex].id;
+        }
+      }
+
+      // Delete the user from project contributors
       const { error } = await supabase
         .from("project_contributors")
         .delete()
         .eq("project_id", projectId)
         .eq("user_id", userData.auth_id);
 
-      if (error) throw error;
+      if (error) {
+        console.error("Error leaving project:", error);
+        toast.error(`Failed to leave project: ${error.message}`);
+        return;
+      }
+
+      // If this user was the current writer, assign a new one based on our earlier calculation
+      if (isCurrentWriter && nextWriterId) {
+        const { error: updateWriterError } = await supabase
+          .from("project_contributors")
+          .update({ current_writer: true })
+          .eq("id", nextWriterId);
+
+        if (updateWriterError) {
+          console.error("Error updating new writer:", updateWriterError);
+        }
+      }
 
       // Update the project's current_contributors_count
       const { error: updateError } = await supabase
@@ -267,14 +521,23 @@ const WritingEditor: React.FC = () => {
         })
         .eq("id", projectId);
 
-      if (updateError) throw updateError;
+      if (updateError) {
+        console.error("Error updating project count:", updateError);
+      }
+
+      // Signal that sessions page needs to refresh data
+      sessionStorage.setItem("refreshSessions", "true");
 
       setIsContributor(false);
       setIsMyTurn(false);
+      setIsProjectCreator(false);
       toast.success("Successfully left the project");
       navigate("/sessions");
-    } catch (error) {
-      toast.error("Failed to leave project");
+    } catch (error: any) {
+      console.error("Leave project error:", error);
+      toast.error(
+        `Failed to leave project: ${error.message || "Unknown error"}`
+      );
     }
   };
 
@@ -286,7 +549,10 @@ const WritingEditor: React.FC = () => {
     }
 
     try {
-      if (!userData?.auth_id) return;
+      if (!userData?.auth_id) {
+        toast.error("User data not available. Please log in again.");
+        return;
+      }
       setIsSubmitting(true);
 
       // Add new snippet
@@ -301,7 +567,12 @@ const WritingEditor: React.FC = () => {
           created_at: new Date().toISOString(),
         });
 
-      if (snippetError) throw snippetError;
+      if (snippetError) {
+        console.error("Error adding new snippet:", snippetError);
+        toast.error(`Failed to submit contribution: ${snippetError.message}`);
+        setIsSubmitting(false);
+        return;
+      }
 
       // Update contributor status
       const { error: contributorError } = await supabase
@@ -314,24 +585,186 @@ const WritingEditor: React.FC = () => {
         .eq("project_id", projectId)
         .eq("user_id", userData.auth_id);
 
-      if (contributorError) throw contributorError;
+      if (contributorError) {
+        console.error("Error updating contributor status:", contributorError);
+        toast.error(
+          `Failed to update contributor status: ${contributorError.message}`
+        );
+        // Continue to pass the pen even if this fails
+      }
+
+      // Fetch all contributors for this project to implement a proper rotation
+      const { data: allContributors, error: allContributorsError } =
+        await supabase
+          .from("project_contributors")
+          .select("*")
+          .eq("project_id", projectId)
+          .order("joined_at", { ascending: true });
+
+      if (allContributorsError) {
+        console.error("Error fetching all contributors:", allContributorsError);
+      }
+
+      let nextWriter = null;
+
+      // If we have contributors, implement a rotation system
+      if (allContributors && allContributors.length > 0) {
+        if (allContributors.length === 1) {
+          // If there's only one contributor (just the current user), they remain the writer
+          nextWriter = allContributors[0];
+        } else {
+          // Find the current writer's index
+          const currentWriterIndex = allContributors.findIndex(
+            (contributor) => contributor.user_id === userData.auth_id
+          );
+
+          // Calculate the next writer's index with rotation
+          // If currentWriterIndex is the last one, go back to index 0
+          const nextWriterIndex =
+            currentWriterIndex === allContributors.length - 1
+              ? 0
+              : currentWriterIndex + 1;
+
+          nextWriter = allContributors[nextWriterIndex];
+        }
+
+        // Update the next writer
+        if (nextWriter) {
+          const { error: updateWriterError } = await supabase
+            .from("project_contributors")
+            .update({ current_writer: true })
+            .eq("id", nextWriter.id);
+
+          if (updateWriterError) {
+            console.error("Error updating next writer:", updateWriterError);
+          }
+        }
+      }
 
       // Immediately fetch updated snippets
       await fetchSnippets();
+
+      // Refresh contributors list
+      await fetchContributors();
 
       toast.success("Contribution submitted successfully!");
       setContent("");
       setWordCount(0);
       setIsMyTurn(false);
-    } catch (error) {
-      toast.error("Failed to submit contribution");
+    } catch (error: any) {
+      console.error("Submit contribution error:", error);
+      toast.error(
+        `Failed to submit contribution: ${error.message || "Unknown error"}`
+      );
     } finally {
       setIsSubmitting(false);
     }
   };
 
+  const handleDeleteProject = async () => {
+    if (
+      !window.confirm(
+        "Are you sure you want to delete this project? This action cannot be undone."
+      )
+    ) {
+      return;
+    }
+
+    try {
+      const { error } = await supabase
+        .from("projects")
+        .delete()
+        .eq("id", projectId);
+
+      if (error) throw error;
+
+      // Signal that sessions page needs to refresh data
+      sessionStorage.setItem("refreshSessions", "true");
+
+      toast.success("Project deleted successfully!");
+      navigate("/sessions");
+    } catch (error) {
+      toast.error("Failed to delete project");
+    }
+  };
+
+  const renderContributors = (contributors: Contributor[]) => {
+    return contributors.map((contributor) => (
+      <div key={contributor.id} className="flex items-center gap-2">
+        {contributor.user_is_project_creator && <Crown className="text-gold" />}
+        <span
+          className={`text-sm font-medium px-3 py-1 rounded-full ${
+            contributor.user_is_project_creator
+              ? "bg-orange-500 text-white"
+              : "bg-secondary text-black"
+          }`}
+        >
+          {contributor.user?.user_profile_name || "Unknown"}
+        </span>
+        {contributor.current_writer && (
+          <PenTool className="text-primary-text" />
+        )}
+      </div>
+    ));
+  };
+
+  const checkIfContributor = async () => {
+    try {
+      const user = await getCurrentUser();
+      if (!user) {
+        // Not logged in, so can't be a contributor
+        setIsContributor(false);
+        return;
+      }
+
+      // Check if user is already a contributor
+      const { data: contributorData, error } = await supabase
+        .from("project_contributors")
+        .select("*") // Select all fields to get additional information like current_writer status
+        .eq("project_id", projectId)
+        .eq("user_id", user.id);
+
+      if (error) {
+        console.error("Error checking contributor status:", error);
+        // Don't throw, handle gracefully
+        setIsContributor(false);
+        return;
+      }
+
+      // Check if contributorData is not empty
+      const isUserContributor = contributorData && contributorData.length > 0;
+      setIsContributor(isUserContributor);
+
+      // If the user is a contributor, update their status
+      if (isUserContributor && contributorData[0]) {
+        setIsMyTurn(contributorData[0].current_writer || false);
+        setIsProjectCreator(
+          contributorData[0].user_is_project_creator || false
+        );
+      }
+    } catch (error) {
+      console.error("Error checking contributor status:", error);
+      // In case of error, assume not a contributor for safety
+      setIsContributor(false);
+    }
+  };
+
+  // Call this function when the component mounts or when the user tries to join
+  useEffect(() => {
+    checkIfContributor();
+  }, [projectId]);
+
   return (
-    <div className="container mx-auto py-8 px-4">
+    <div className="container mx-auto py-8 px-4 pb-16 max-w-xl">
+      <div className="mb-4">
+        <Button
+          variant="outline"
+          onClick={() => navigate("/sessions")}
+          className="text-sm"
+        >
+          Back to Sessions
+        </Button>
+      </div>
       <Card>
         <CardHeader>
           <CardTitle>{project?.title || "Loading..."}</CardTitle>
@@ -342,7 +775,9 @@ const WritingEditor: React.FC = () => {
             {isLoading ? (
               <Skeleton className="h-4 w-3/4" />
             ) : (
-              <p className="text-secondary-text">{project?.description}</p>
+              <p className="text-secondary-text text-justify">
+                {project?.description}
+              </p>
             )}
           </div>
 
@@ -383,6 +818,20 @@ const WritingEditor: React.FC = () => {
                   </p>
                 </div>
               ))
+            )}
+          </div>
+
+          {/* Contributors section */}
+          <div className="mb-6">
+            <h3 className="text-lg font-semibold mb-2">Contributors:</h3>
+            {loadingContributors ? (
+              <Skeleton className="h-10 w-full" />
+            ) : contributors.length > 0 ? (
+              <div className="flex flex-wrap gap-2">
+                {renderContributors(contributors)}
+              </div>
+            ) : (
+              <p className="text-secondary-text">No contributors yet</p>
             )}
           </div>
 
@@ -431,14 +880,23 @@ const WritingEditor: React.FC = () => {
                     Waiting for your turn...
                   </p>
                 )}
-                <Button
-                  variant="outline"
-                  onClick={handleLeave}
-                  className="mt-4"
-                  disabled={isSubmitting}
-                >
-                  Leave Project
-                </Button>
+                <div className="flex justify-center mt-4 gap-4">
+                  <Button
+                    variant="outline"
+                    onClick={handleLeave}
+                    disabled={isSubmitting}
+                  >
+                    Leave Project
+                  </Button>
+                  {isProjectCreator && (
+                    <Button
+                      className="bg-red-500 hover:bg-red-600 text-white"
+                      onClick={handleDeleteProject}
+                    >
+                      Delete Project
+                    </Button>
+                  )}
+                </div>
               </div>
             </>
           ) : (

--- a/frontend/src/styles/Footer.css
+++ b/frontend/src/styles/Footer.css
@@ -1,0 +1,8 @@
+footer {
+  position: fixed;
+  bottom: 0;
+  left: 0;
+  width: 100%;
+  background-color: #ffffff; /* Adjust to your design */
+  z-index: 1000; /* Ensure it's above other content */
+}

--- a/frontend/src/styles/Footer.css
+++ b/frontend/src/styles/Footer.css
@@ -1,8 +1,1 @@
-footer {
-  position: fixed;
-  bottom: 0;
-  left: 0;
-  width: 100%;
-  background-color: #ffffff; /* Adjust to your design */
-  z-index: 1000; /* Ensure it's above other content */
-}
+/* added inappropriatly - safe to delete after merge */

--- a/frontend/src/styles/Header.css
+++ b/frontend/src/styles/Header.css
@@ -1,0 +1,8 @@
+header {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  background-color: #ffffff; /* Adjust to your design */
+  z-index: 1000; /* Ensure it's above other content */
+}

--- a/frontend/src/styles/Header.css
+++ b/frontend/src/styles/Header.css
@@ -1,8 +1,1 @@
-header {
-  position: fixed;
-  top: 0;
-  left: 0;
-  width: 100%;
-  background-color: #ffffff; /* Adjust to your design */
-  z-index: 1000; /* Ensure it's above other content */
-}
+/* added inappropriatly - safe to delete after merge */ 

--- a/frontend/src/types/global.d.ts
+++ b/frontend/src/types/global.d.ts
@@ -9,24 +9,23 @@ interface UserProfile {
 interface ProjectContributor {
   contributor_id: string;
   contributor?: UserProfile;
+  user_is_project_creator?: boolean;
 }
 
 export interface ProjectsData {
   id: string;
-  creator_id: string;
   title: string;
   description: string;
   project_genre: string;
+  is_completed: boolean;
+  creator_id: string;
+  creator: {
+    auth_id: string;
+    user_profile_name: string;
+  } | null;
+  created_at: Date;
   current_contributors_count: number;
   max_contributors: number;
-  is_mature_content: boolean;
-  is_public: boolean;
-  created_at: Date;
-  updated_at: Date;
-  is_completed: boolean;
-  total_contributors: number;
-  current_contributors_count: number;
-  creator?: UserProfile;
   project_contributors?: ProjectContributor[];
 }
 

--- a/frontend/src/utils/supabase.tsx
+++ b/frontend/src/utils/supabase.tsx
@@ -83,7 +83,7 @@ export const getProjectOfId = async (
 
 export const getSessions = async () => {
   try {
-    // First, let's try a simpler query to test the connection
+    // only get projects that have not been flagged as completed
     const { data: project, error } = await supabase
       .from("projects")
       .select("*")
@@ -93,7 +93,7 @@ export const getSessions = async () => {
       throw error;
     }
 
-    // If the basic query works, then let's get the related data
+    // if the basic query succeeds, then get the data we need
     const { data: fullProject, error: fullError } = await supabase
       .from("projects")
       .select(
@@ -114,46 +114,94 @@ export const getSessions = async () => {
     }
 
     console.log("Raw query result:", fullProject);
+
+    // Update the contributor counts with real-time data
     if (fullProject && fullProject.length > 0) {
-      console.log("First project creator:", fullProject[0].creator);
-      console.log("Creator ID of first project:", fullProject[0].creator_id);
+      console.log("Updating contributor counts...");
+
+      try {
+        // For each project, get the actual count of contributors
+        for (const project of fullProject) {
+          const { data: contributors, error: countError } = await supabase
+            .from("project_contributors")
+            .select("id")
+            .eq("project_id", project.id);
+
+          if (countError) {
+            console.error(
+              `Error fetching contributors for project ${project.id}:`,
+              countError
+            );
+          } else if (contributors) {
+            const realCount = contributors.length;
+            if (realCount !== project.current_contributors_count) {
+              console.log(
+                `Updating project ${project.id} count from ${project.current_contributors_count} to ${realCount}`
+              );
+              project.current_contributors_count = realCount;
+
+              // Also update the project table to keep it in sync
+              const { error: updateError } = await supabase
+                .from("projects")
+                .update({ current_contributors_count: realCount })
+                .eq("id", project.id);
+
+              if (updateError) {
+                console.error(
+                  `Error updating project count in database:`,
+                  updateError
+                );
+              }
+            }
+          }
+        }
+      } catch (countErr) {
+        console.error("Error updating contributor counts:", countErr);
+      }
     }
+
     return fullProject || project;
   } catch (err) {
+    console.error("Error in getSessions:", err);
     return null;
   }
 };
 
-// get all projects + genre .where is_completed = true
+// get all projects + genre where is_completed = true
 export const getProjects = async (): Promise<ProjectsData[] | null> => {
-  const { data: project, error } = await supabase
-    .from("projects")
-    .select(
-      `
-      *,
-      creator:users_ext(
-        auth_id,
-        user_profile_name
-      ),
-      project_contributors(
-        contributor_id,
-        contributor:users_ext(
-          auth_id,
+  try {
+    const { data, error } = await supabase
+      .from("projects")
+      .select(
+        `
+        id,
+        title,
+        description,
+        project_genre,
+        is_completed,
+        creator_id,
+        creator:users_ext!creator_id(
           user_profile_name
         )
+      `
       )
-    `
-    )
-    .eq("is_completed", true);
+      .eq("is_completed", true);
 
-  if (error) {
-    throw error;
+    if (error) {
+      console.error("Error fetching projects:", error.message);
+      console.error("Error details:", error.details);
+      return null;
+    }
+
+    console.log("Fetched projects:", data); // Debug output
+    return data as ProjectsData[];
+  } catch (err) {
+    console.error("Exception in getProjects:", err);
+    return null;
   }
-
-  return project;
 };
 
-// Function to fetch tags from Supabase
+// function to fetch tags (currently just used for genres) from Supabase
 export const getTags = async () => {
   const { data, error } = await supabase.from("tags").select("*").order("name");
 
@@ -194,6 +242,7 @@ const updateUsername = async (username: string): Promise<any> => {
   }
 };
 
+// updates the user bio field
 const updateBio = async (bio: string): Promise<any> => {
   const currentUser: User | null = await getCurrentUser();
 
@@ -207,6 +256,7 @@ const updateBio = async (bio: string): Promise<any> => {
   }
 };
 
+// enable viewing mature content flag on user profile
 const updateMatureContent = async (matureContent: boolean): Promise<any> => {
   const currentUser: User | null = await getCurrentUser();
 
@@ -220,6 +270,7 @@ const updateMatureContent = async (matureContent: boolean): Promise<any> => {
   }
 };
 
+// returns the verbose username by user id
 const getUsername = async (): Promise<any> => {
   const currentUser: User | null = await getCurrentUser();
 
@@ -265,6 +316,127 @@ const getMatureContent = async (): Promise<any> => {
   return data;
 };
 
+// explicit function to get all contributors to a given project (type definitions are here temporarily for debugging)
+
+// Typing
+export interface Contributor {
+  id: string;
+  user_id: string;
+  project_id: string;
+  user_made_contribution: boolean;
+  current_writer: boolean;
+  joined_at?: string;
+  last_contribution_at?: string;
+  user?: {
+    id: string;
+    user_profile_name: string;
+  };
+}
+
+/**
+ * Fetches all contributors for a specific project with correct user information
+ *
+ * @param projectId - The UUID of the project
+ * @returns Array of contributors with user information
+ */
+async function getProjectContributors(projectId: string) {
+  try {
+    // Step 1: First get basic contributor data with simple query
+    console.log(`Fetching contributors for project: ${projectId}`);
+    const { data: contributors, error: contributorsError } = await supabase
+      .from("project_contributors")
+      .select("*")
+      .eq("project_id", projectId);
+
+    if (contributorsError) {
+      console.error("Error fetching project contributors:", contributorsError);
+      return [];
+    }
+
+    console.log(`Found ${contributors?.length || 0} contributors`);
+
+    // Debug log to help identify the current writer issue
+    if (contributors && contributors.length > 0) {
+      const currentWriter = contributors.find((c) => c.current_writer === true);
+      console.log(
+        "Current writer from DB:",
+        currentWriter
+          ? `User ID: ${currentWriter.user_id}, current_writer: ${currentWriter.current_writer}`
+          : "No current writer found in data"
+      );
+
+      console.log(
+        "All contributors current_writer status:",
+        contributors.map((c) => ({
+          user_id: c.user_id,
+          current_writer: c.current_writer,
+        }))
+      );
+    }
+
+    // If no contributors or empty array, return early
+    if (!contributors || contributors.length === 0) {
+      return [];
+    }
+
+    // Step 2: Now get user data for each contributor
+    const userIds = contributors.map((contributor) => contributor.user_id);
+    console.log(`Fetching user data for user IDs:`, userIds);
+
+    // Make sure we're querying the correct users table
+    // Check your Supabase schema to ensure this is the right table and fields
+    const { data: usersData, error: usersError } = await supabase
+      .from("users_ext") // Make sure this is the correct table name
+      .select("id, user_profile_name")
+      .in("id", userIds);
+
+    if (usersError) {
+      console.error("Error fetching user data:", usersError);
+      // Return contributors without user info rather than an empty array
+      return contributors.map((contributor) => ({
+        ...contributor,
+        user: { id: contributor.user_id, user_profile_name: "Unknown" },
+      }));
+    }
+
+    console.log(`Found ${usersData?.length || 0} users`);
+
+    // Step 3: Combine contributor and user data with safe handling of null values
+    const enrichedContributors = contributors.map((contributor) => {
+      const user = usersData?.find((user) => user.id === contributor.user_id);
+
+      // Ensure all expected fields have sensible defaults
+      return {
+        ...contributor,
+        user_made_contribution: contributor.user_made_contribution || false,
+        current_writer: contributor.current_writer || false,
+        user_is_project_creator: contributor.user_is_project_creator || false,
+        last_contribution_at:
+          contributor.last_contribution_at ||
+          contributor.joined_at ||
+          new Date().toISOString(),
+        user: user || { id: contributor.user_id, user_profile_name: "Unknown" },
+      };
+    });
+
+    // Final check - log the enriched contributors with writer status
+    const finalCurrentWriter = enrichedContributors.find(
+      (c) => c.current_writer === true
+    );
+    console.log(
+      "Final current writer after processing:",
+      finalCurrentWriter
+        ? `${finalCurrentWriter.user?.user_profile_name}, current_writer: ${finalCurrentWriter.current_writer}`
+        : "No current writer found"
+    );
+
+    return enrichedContributors;
+  } catch (err) {
+    console.error("Exception when fetching project contributors:", err);
+    return [];
+  }
+}
+
 export {
   supabase,
   signUp,
@@ -274,6 +446,7 @@ export {
   getUsername,
   getBio,
   getMatureContent,
+  getProjectContributors,
   getSession,
   insertUsername,
   updateUsername,


### PR DESCRIPTION
### Features added: 

- **adds round-robin writing queue**
  - users who join a project will be placed in the queue after existing users
  - users who leave a project are now validation prompted

- **adds ability for project creators to delete an active project**
  - deletion has validation reminder that action cannot be undone
  - currently there is no input from secondary users for deletion 

- **adds visual indicators for project creator and current "pen-holder"**
  - also adds text indicator "Waiting for your turn..." if user is on the project but waiting in queue 
 
- **properly displays number of users on projects**
  - legacy projects created before this functionality was added still show 0 users - this is a known behavior. Manually fixing this in the databse is not recommended but the projects should be preserved for posterity until release candidate 
  - contributors user_name properly displays on WritingEditor page

**- If a user is a contributor on the project, rejoining upon logout is now prevented**
  - user queue position is appropriately maintained across logins
  - user projects are appropriately maintained across logins 

**- page refresh no longer inappropriately navigates user to login page**
  - users are properly navigated to previous page view on refresh 
  - user state with the exception of current writing on WritingEditor is preserved appropriately 