### PR TITLE
feat: genre reflect the database table in alphabetical order

### DIFF
--- a/frontend/src/components/GenreFilter.tsx
+++ b/frontend/src/components/GenreFilter.tsx
@@ -5,12 +5,17 @@ import { ToggleGroup, ToggleGroupItem } from "@/components/ui/toggle-group";
 const genres: string[] = [
   "All",
   "Adventure",
-  "Horror",
-  "Romance",
-  "Mystery",
-  "Sci-Fi",
-  "Fantasy",
   "Comedy",
+  "Crime",
+  "Fantasy",
+  "History",
+  "Horror",
+  "Mystery",
+  "Paranormal",
+  "Romance",
+  "Sci-Fi",
+  "Thriller",
+  "Western",
 ];
 interface GenreFilterProps {
   onSelect: (genre: string) => void;

--- a/frontend/src/components/ProjectCard.tsx
+++ b/frontend/src/components/ProjectCard.tsx
@@ -32,7 +32,7 @@ const ProjectCard: React.FC<ProjectCardDataProp> = ({ projectData }) => {
       // Get user's auth_id from users_ext
       const { data: userExtData, error: userExtError } = await supabase
         .from("users_ext")
-        .select("*")
+        .select("id")
         .eq("user_email", user.email)
         .single();
 
@@ -41,14 +41,15 @@ const ProjectCard: React.FC<ProjectCardDataProp> = ({ projectData }) => {
       // Check if user is a contributor
       const { data: contributorData, error: contributorError } = await supabase
         .from("project_contributors")
-        .select("*")
+        .select("id")
         .eq("project_id", projectData.id)
         .eq("user_id", userExtData.id)
+        .eq("user_made_contribution", true)
         .single();
 
       if (contributorError) return;
 
-      // gives true user is in the project, but maybe should check if => user_made_contribution is true
+      // gives true user is in the project
       setIsContributor(!!contributorData);
     };
 


### PR DESCRIPTION
quick update on the genre filter to have all the genre from the database. Decided to hard code them since it saves a call and the genre appear instantly, also in alphabetical order.

on the ProjectCard I changed the checkContributorStatus to not select the whole table as we just needed confirmation that the user is a contributor of the project.