### PR TITLE
fix: corrects improper profile->story navigation

### DIFF
--- a/frontend/src/components/navigation_pages/ReadingPage.tsx
+++ b/frontend/src/components/navigation_pages/ReadingPage.tsx
@@ -185,16 +185,24 @@ const ReadingPage: React.FC = () => {
       <Card className="border-none shadow-none md:shadow-lg">
         <CardHeader className="mb-2">
           <CardTitle className="text-3xl font-bold text-primary-text mb-2">
-            {project?.title}
+            {project?.title || projectData?.title}
           </CardTitle>
           <div className="flex flex-wrap gap-4 items-center text-secondary-text">
-            <Badge className={`genre-${project.project_genre.toLowerCase()}`}>
-              {project?.project_genre}
+            <Badge
+              className={`genre-${
+                projectData?.project_genre?.toLowerCase() || ""
+              }`}
+            >
+              {projectData?.project_genre ||
+                project?.project_genre ||
+                "Unknown"}
             </Badge>
             <span className="text-secondary-text">
               Completed:{" "}
-              {project?.updated_at
-                ? new Date(project.updated_at).toDateString()
+              {project?.updated_at || projectData?.updated_at
+                ? new Date(
+                    project?.updated_at || projectData?.updated_at
+                  ).toDateString()
                 : "No date found"}
             </span>
           </div>


### PR DESCRIPTION
Not sure if this is a redundant pull request but this commit fixes user-expected navigation behaviour. 

Previous issue: Users expected all navigation routes to start at Sessions page. 
Demonstrated behaviour: Logging in navigated users to the Sessions page, while the "Explore Stories" button navigated users to the Stories page. 

Corrected behaviour: All entry routes now navigate the user to Sessions page as users have expressed they expect.  