### PR TITLE
Profile and settings pages merge

### DIFF
--- a/frontend/src/components/Header.tsx
+++ b/frontend/src/components/Header.tsx
@@ -221,7 +221,7 @@ const Header: React.FC<HeaderProps> = function Header({ loggedIn, page }) {
                       <User />
                       <p>Profile</p>
                     </button>
-                    <button
+                    {/* <button
                       onClick={() => {
                         setPopoverOpen(false);
                         navigate("/settings");
@@ -230,7 +230,7 @@ const Header: React.FC<HeaderProps> = function Header({ loggedIn, page }) {
                     >
                       <Settings />
                       <p>Settings</p>
-                    </button>
+                    </button> */}
                   </div>
                   <button
                     onClick={handleLogout}

--- a/frontend/src/components/Header.tsx
+++ b/frontend/src/components/Header.tsx
@@ -296,13 +296,13 @@ const Header: React.FC<HeaderProps> = function Header({ loggedIn, page }) {
                     <p>Create</p>
                   </a>
 
-                  <a
+                  {/* <a
                     href="/settings"
                     className="w-full flex gap-2 p-2 text-primary-text cursor-pointer hover:bg-menu-hover"
                   >
                     <Settings />
                     <p>Settings</p>
-                  </a>
+                  </a> */}
                   <a
                     onClick={handleLogout}
                     className=" w-full flex gap-2 p-2 text-primary-text cursor-pointer hover:bg-menu-hover"

--- a/frontend/src/components/ProfileSettings.tsx
+++ b/frontend/src/components/ProfileSettings.tsx
@@ -180,7 +180,7 @@ const ProfileSettings: React.FC<EditingToggleProps> = ({
                   <FormControl>
                     <Textarea
                       placeholder="Share a glimpse of your story with others."
-                      className="mt-1 block w-full rounded-md border border-primary-border bg-white px-4 py-2 text-primary-text shadow-sm focus:outline-none focus-visible:ring-1 focus-visible:ring-input-focus focus-visible:border-input-focus sm:text-sm"
+                      className="mt-1 block w-full rounded-md border border-primary-border resize-y max-h-38 bg-white px-4 py-2 text-primary-text shadow-sm focus:outline-none focus-visible:ring-1 focus-visible:ring-input-focus focus-visible:border-input-focus sm:text-sm"
                       onChange={(e) => handleBioChange(e, field.onChange)}
                       value={field.value}
                       maxLength={180}

--- a/frontend/src/components/ProfileSettings.tsx
+++ b/frontend/src/components/ProfileSettings.tsx
@@ -1,0 +1,229 @@
+/* eslint-disable @typescript-eslint/no-unused-expressions */
+import React, { useState, useEffect } from "react";
+import { z } from "zod";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { useForm } from "react-hook-form";
+import { settingsSchema } from "@/utils/formSchemas";
+import { toast } from "sonner";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Textarea } from "@/components/ui/textarea";
+import { Loader2 } from "lucide-react";
+import {
+  getUserProfileData,
+  updateUsername,
+  updateBio,
+} from "@/utils/supabase";
+import {
+  Form,
+  FormControl,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from "@/components/ui/form";
+import axios from "axios";
+
+interface EditingToggleProps {
+  isEditing: boolean;
+  setIsEditing: React.Dispatch<React.SetStateAction<boolean>>;
+  setBio: React.Dispatch<React.SetStateAction<string>>;
+  setUsername: React.Dispatch<React.SetStateAction<string>>;
+}
+
+const API_BASE_URL =
+  (import.meta.env.VITE_BACKEND_URL as string) || "http://localhost:8080";
+
+const ProfileSettings: React.FC<EditingToggleProps> = ({
+  isEditing,
+  setIsEditing,
+  setBio,
+  setUsername,
+}) => {
+  // Setting states
+  const [isLoading, setIsLoading] = useState<boolean>(false);
+  const [bioCharCount, setBioCharCount] = useState<number>(0);
+
+  // Form Validation
+  const form = useForm<z.infer<typeof settingsSchema>>({
+    resolver: zodResolver(settingsSchema),
+    defaultValues: {
+      username: "",
+      bio: "",
+    },
+  });
+
+  // Fetch user data on mount
+  useEffect(() => {
+    const fetchSettingsData = async () => {
+      try {
+        const userData = await getUserProfileData();
+
+        let username = userData.username;
+        if (username.includes("@")) {
+          username = username.substring(0, username.indexOf("@"));
+        }
+
+        const bioText = userData.bio || "";
+        setBioCharCount(bioText ? bioText.length : 0);
+
+        // Set form values after data is fetched
+        form.reset({
+          username: username,
+          bio: bioText,
+        });
+      } catch (error) {
+        console.error("Error fetching settings data:", error);
+        toast.error("Failed to load settings");
+      }
+    };
+
+    fetchSettingsData();
+  }, [form]);
+
+  // Form Submission
+  async function onSubmit(values: z.infer<typeof settingsSchema>) {
+    try {
+      setIsLoading(true);
+
+      console.log(values);
+
+      //   Check if any of the fields have data
+      //   if (values.username.length > 0 || values.bio.length > 0) {
+      //     const moderationResponse = await axios.post(
+      //       `${API_BASE_URL}/moderation`,
+      //       {
+      //         content: values.username + " " + values.bio,
+      //       }
+      //     );
+
+      //     // If content is flagged, display reason
+      //     if (moderationResponse.data.flagged) {
+      //       toast.error(
+      //         `Content flagged for ${moderationResponse.data.reason}. Please try again.`
+      //       );
+      //       setIsLoading(false);
+      //       return;
+      //     }
+      //   }
+
+      // Update username and bio
+      if (values.username.length > 0) {
+        await updateUsername(values.username);
+        sessionStorage.setItem("username", values.username);
+        setUsername(values.username);
+      }
+      if (values.bio.length > 0) {
+        await updateBio(values.bio);
+        setBio(values.bio);
+      }
+
+      toast.success("Successfully Saved Changes");
+    } catch (error: any) {
+      toast.error(`${error.message}`);
+    } finally {
+      setIsLoading(false);
+    }
+  }
+
+  // Handle bio text change
+  const handleBioChange = (
+    e: React.ChangeEvent<HTMLTextAreaElement>,
+    onChange: (value: string) => void
+  ) => {
+    const value = e.target.value;
+
+    // Limit to 180 characters
+    if (value.length <= 180) {
+      onChange(value);
+      setBioCharCount(value.length);
+    }
+  };
+
+  return (
+    <Form {...form}>
+      <form
+        onSubmit={form.handleSubmit(onSubmit)}
+        className="space-y-8 max-w-3xl mx-auto bg-white"
+      >
+        <div className="flex flex-col gap-4 ">
+          {/* Username Input */}
+          <FormField
+            control={form.control}
+            name="username"
+            render={({ field }) => (
+              <FormItem>
+                <FormLabel className="text-sm font-medium text-primary-text text-left">
+                  Username
+                </FormLabel>
+                <FormControl>
+                  <Input
+                    className="mt-1 block w-full rounded-md border border-primary-border bg-white px-4 py-2 text-primary-text shadow-sm focus:outline-none focus-visible:ring-1 focus-visible:ring-input-focus focus-visible:border-input-focus sm:text-sm"
+                    placeholder="Username"
+                    type="text"
+                    {...field}
+                  />
+                </FormControl>
+                <FormMessage className="text-left" />
+              </FormItem>
+            )}
+          />
+
+          {/* Bio Input */}
+          <FormField
+            control={form.control}
+            name="bio"
+            render={({ field }) => (
+              <FormItem>
+                <FormLabel className="text-sm font-medium text-primary-text text-left">
+                  Bio
+                </FormLabel>
+                <div className="flex flex-col">
+                  <FormControl>
+                    <Textarea
+                      placeholder="Share a glimpse of your story with others."
+                      className="mt-1 block w-full rounded-md border border-primary-border bg-white px-4 py-2 text-primary-text shadow-sm focus:outline-none focus-visible:ring-1 focus-visible:ring-input-focus focus-visible:border-input-focus sm:text-sm"
+                      onChange={(e) => handleBioChange(e, field.onChange)}
+                      value={field.value}
+                      maxLength={180}
+                    />
+                  </FormControl>
+                  <div className="text-xs text-tertiary-text text-right mt-1">
+                    {bioCharCount}/180 characters
+                  </div>
+                </div>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+
+          {/* Save  & Cancel Changes Button */}
+          <div className="flex gap-3 ">
+            <Button
+              className=" w-auto bg-primary-button hover:bg-primary-button-hover cursor-pointer"
+              variant="default"
+              type="submit"
+              disabled={isLoading}
+            >
+              {isLoading ? (
+                <>
+                  <Loader2 className="animate-spin" /> Saving Changes
+                </>
+              ) : (
+                "Save Changes"
+              )}
+            </Button>
+            <Button
+              onClick={() => setIsEditing(!isEditing)}
+              className="w-auto bg-gray-100 text-black border border-gray-300 hover:bg-gray-200 cursor-pointer"
+            >
+              Cancel
+            </Button>
+          </div>
+        </div>
+      </form>
+    </Form>
+  );
+};
+
+export default ProfileSettings;

--- a/frontend/src/components/ProfileSettings.tsx
+++ b/frontend/src/components/ProfileSettings.tsx
@@ -86,8 +86,6 @@ const ProfileSettings: React.FC<EditingToggleProps> = ({
     try {
       setIsLoading(true);
 
-      console.log(values);
-
       //   Check if any of the fields have data
       //   if (values.username.length > 0 || values.bio.length > 0) {
       //     const moderationResponse = await axios.post(
@@ -113,7 +111,7 @@ const ProfileSettings: React.FC<EditingToggleProps> = ({
         sessionStorage.setItem("username", values.username);
         setUsername(values.username);
       }
-      if (values.bio.length > 0) {
+      if (values.bio.length > 0 || values.bio === "") {
         await updateBio(values.bio);
         setBio(values.bio);
       }

--- a/frontend/src/components/ProfileSettings.tsx
+++ b/frontend/src/components/ProfileSettings.tsx
@@ -86,24 +86,24 @@ const ProfileSettings: React.FC<EditingToggleProps> = ({
     try {
       setIsLoading(true);
 
-      //   Check if any of the fields have data
-      //   if (values.username.length > 0 || values.bio.length > 0) {
-      //     const moderationResponse = await axios.post(
-      //       `${API_BASE_URL}/moderation`,
-      //       {
-      //         content: values.username + " " + values.bio,
-      //       }
-      //     );
+      // Check if any of the fields have data
+      if (values.username.length > 0 || values.bio.length > 0) {
+        const moderationResponse = await axios.post(
+          `${API_BASE_URL}/moderation`,
+          {
+            content: values.username + " " + values.bio,
+          }
+        );
 
-      //     // If content is flagged, display reason
-      //     if (moderationResponse.data.flagged) {
-      //       toast.error(
-      //         `Content flagged for ${moderationResponse.data.reason}. Please try again.`
-      //       );
-      //       setIsLoading(false);
-      //       return;
-      //     }
-      //   }
+        // If content is flagged, display reason
+        if (moderationResponse.data.flagged) {
+          toast.error(
+            `Content flagged for ${moderationResponse.data.reason}. Please try again.`
+          );
+          setIsLoading(false);
+          return;
+        }
+      }
 
       // Update username and bio
       if (values.username.length > 0) {

--- a/frontend/src/components/ProfileStoriesCard.tsx
+++ b/frontend/src/components/ProfileStoriesCard.tsx
@@ -39,10 +39,18 @@ const ProfileStoriesCard: React.FC<ProfileStoriesCardProps> = ({
   const formattedCreationDate = format(new Date(creationDate), "MMM dd, yyyy");
   const formattedLastUpdatedDate = formatDistanceToNow(new Date(lastUpdated));
 
+  console.log(currentTab);
+
   return (
     <Card
       className="w-[350px] bg-background-card  flex flex-col cursor-pointer"
-      onClick={() => navigate(`/projects/${storyId}/read`)}
+      onClick={() => {
+        if (currentTab === "Completed") {
+          navigate(`/projects/${storyId}/read`);
+        } else {
+          navigate(`/writing/${storyId}`);
+        }
+      }}
     >
       <CardHeader>
         <div className="flex justify-between items-center">

--- a/frontend/src/components/ProfileStoriesCard.tsx
+++ b/frontend/src/components/ProfileStoriesCard.tsx
@@ -39,8 +39,6 @@ const ProfileStoriesCard: React.FC<ProfileStoriesCardProps> = ({
   const formattedCreationDate = format(new Date(creationDate), "MMM dd, yyyy");
   const formattedLastUpdatedDate = formatDistanceToNow(new Date(lastUpdated));
 
-  console.log(currentTab);
-
   return (
     <Card
       className="w-[350px] bg-background-card  flex flex-col cursor-pointer"

--- a/frontend/src/components/ProjectCard.tsx
+++ b/frontend/src/components/ProjectCard.tsx
@@ -98,7 +98,14 @@ const ProjectCard: React.FC<ProjectCardDataProp> = ({ projectData }) => {
   );
 
   return (
-    <Card className="w-[300px] h-[327px] bg-background-card ">
+    <Card
+      className="w-[300px] h-[327px] bg-background-card cursor-pointer"
+      onClick={() =>
+        navigate(`/projects/${projectData.id}/read`, {
+          state: { project: projectData },
+        })
+      }
+    >
       {/* header of card => Genre, Title, Contributors */}
       <CardHeader className="flex-none space-y-3 h-[76px]">
         <CardHeaderWithMature

--- a/frontend/src/components/SessionCard.tsx
+++ b/frontend/src/components/SessionCard.tsx
@@ -89,7 +89,10 @@ const SessionCard: React.FC<SessionCardDataProp> = ({
   );
 
   return (
-    <Card className="w-[300px] h-[327px] bg-background-card">
+    <Card
+      className="w-[300px] h-[327px] bg-background-card cursor-pointer"
+      onClick={() => navigate(`/writing/${sessionData.id}`)}
+    >
       <CardHeader className="flex-none space-y-3 h-[76px]">
         <CardHeaderWithMature
           genre={sessionData.project_genre}

--- a/frontend/src/components/UserSettings.tsx
+++ b/frontend/src/components/UserSettings.tsx
@@ -32,7 +32,6 @@ const UserSettings: React.FC<UserSettingsProps> = ({ userPreference }) => {
   // Handle mature toggle
   const handleMatureToggle = async (checked: boolean) => {
     setMatureContent(checked);
-    console.log(checked);
 
     try {
       await updateMatureContent(checked);

--- a/frontend/src/components/UserSettings.tsx
+++ b/frontend/src/components/UserSettings.tsx
@@ -1,0 +1,142 @@
+/* eslint-disable @typescript-eslint/no-unused-expressions */
+import React, { useState } from "react";
+import { toast } from "sonner";
+import { Button } from "@/components/ui/button";
+import { Switch } from "@/components/ui/switch";
+import { Loader2, Settings, AlertTriangle } from "lucide-react";
+import { deleteUserAccount } from "@/utils/supabase";
+import { updateMatureContent } from "@/utils/supabase";
+import { useNavigate } from "react-router-dom";
+import {
+  AlertDialog,
+  AlertDialogTrigger,
+  AlertDialogContent,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogCancel,
+} from "@/components/ui/alert-dialog"; // Import shadcn AlertDialog components
+
+interface UserSettingsProps {
+  userPreference: boolean;
+}
+
+const UserSettings: React.FC<UserSettingsProps> = ({ userPreference }) => {
+  // Setting states
+  const [isDeletingAccount, setIsDeletingAccount] = useState<boolean>(false);
+  const [matureContent, setMatureContent] = useState<boolean>(userPreference);
+
+  const navigate = useNavigate();
+
+  // Handle mature toggle
+  const handleMatureToggle = async (checked: boolean) => {
+    setMatureContent(checked);
+    console.log(checked);
+
+    try {
+      await updateMatureContent(checked);
+      toast.success(
+        checked ? "Mature content enabled" : "Mature content disabled"
+      );
+    } catch (error: any) {
+      toast.error(`${error.message}`);
+      // Revert the switch if the update failed
+      setMatureContent(!checked);
+    }
+  };
+
+  // Account Deletion Handler
+  const handleDeleteAccount = async () => {
+    try {
+      setIsDeletingAccount(true);
+      const result = await deleteUserAccount();
+
+      if (result.success) {
+        toast.success(result.message);
+        // Navigate to landing page after successful deletion
+        navigate("/");
+      } else {
+        toast.error(result.message);
+      }
+    } catch (error: any) {
+      console.error(error);
+      toast.error("Failed to delete account. Please try again.");
+    } finally {
+      setIsDeletingAccount(false);
+    }
+  };
+
+  return (
+    <>
+      {/* Icon to open the AlertDialog */}
+      <AlertDialog>
+        <AlertDialogTrigger asChild>
+          <button className=" hover:scale-110 transition-transform duration-200">
+            <Settings className="h-6 w-6" />
+          </button>
+        </AlertDialogTrigger>
+
+        {/* AlertDialog Content */}
+        <AlertDialogContent className="bg-white">
+          <AlertDialogHeader>
+            <AlertDialogTitle>User Settings</AlertDialogTitle>
+            <AlertDialogDescription>
+              Manage your preferences and account settings.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+
+          {/* Allow Mature Content Switch */}
+          <div className="flex items-center space-x-2 mb-4">
+            <label
+              htmlFor="mature-content-toggle"
+              className="text-sm font-medium"
+            >
+              Allow Mature Content
+            </label>
+            <Switch
+              id="mature-content-toggle"
+              checked={matureContent}
+              onCheckedChange={handleMatureToggle}
+            />
+          </div>
+
+          {/* Danger Zone: Delete Account */}
+          <div className="border-t pt-4">
+            <h4 className="text-lg font-medium mb-3">Danger Zone</h4>
+            <p className="text-sm text-tertiary-text mb-4">
+              Delete user account and information from Inkprov
+            </p>
+            <Button
+              variant="destructive"
+              className="w-[80%] sm:w-[50%] flex items-center justify-center gap-2"
+              onClick={handleDeleteAccount}
+              disabled={isDeletingAccount}
+            >
+              {isDeletingAccount ? (
+                <>
+                  <Loader2 className="h-5 w-5 animate-spin" />
+                  Deleting Account...
+                </>
+              ) : (
+                <>
+                  <AlertTriangle className="h-5 w-5" />
+                  Delete Account
+                </>
+              )}
+            </Button>
+          </div>
+
+          {/* AlertDialog Footer */}
+          <AlertDialogFooter>
+            <AlertDialogCancel className="bg-white w-25">
+              Close
+            </AlertDialogCancel>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+    </>
+  );
+};
+
+export default UserSettings;

--- a/frontend/src/components/UserSettings.tsx
+++ b/frontend/src/components/UserSettings.tsx
@@ -71,8 +71,8 @@ const UserSettings: React.FC<UserSettingsProps> = ({ userPreference }) => {
       {/* Icon to open the AlertDialog */}
       <AlertDialog>
         <AlertDialogTrigger asChild>
-          <button className=" hover:scale-110 transition-transform duration-200">
-            <Settings className="h-6 w-6" />
+          <button className=" hover:scale-110 transition-transform duration-200 cursor-pointer">
+            <Settings className="h-6 w-6 " />
           </button>
         </AlertDialogTrigger>
 
@@ -97,6 +97,7 @@ const UserSettings: React.FC<UserSettingsProps> = ({ userPreference }) => {
               id="mature-content-toggle"
               checked={matureContent}
               onCheckedChange={handleMatureToggle}
+              className="cursor-pointer"
             />
           </div>
 
@@ -108,7 +109,7 @@ const UserSettings: React.FC<UserSettingsProps> = ({ userPreference }) => {
             </p>
             <Button
               variant="destructive"
-              className="w-[80%] sm:w-[50%] flex items-center justify-center gap-2"
+              className="w-[80%] sm:w-[50%] flex items-center justify-center gap-2 cursor-pointer"
               onClick={handleDeleteAccount}
               disabled={isDeletingAccount}
             >
@@ -119,7 +120,7 @@ const UserSettings: React.FC<UserSettingsProps> = ({ userPreference }) => {
                 </>
               ) : (
                 <>
-                  <AlertTriangle className="h-5 w-5" />
+                  <AlertTriangle className="h-5 w-5 " />
                   Delete Account
                 </>
               )}
@@ -128,7 +129,7 @@ const UserSettings: React.FC<UserSettingsProps> = ({ userPreference }) => {
 
           {/* AlertDialog Footer */}
           <AlertDialogFooter>
-            <AlertDialogCancel className="bg-white w-25">
+            <AlertDialogCancel className="bg-white w-25 cursor-pointer">
               Close
             </AlertDialogCancel>
           </AlertDialogFooter>

--- a/frontend/src/components/navigation_pages/Profile.tsx
+++ b/frontend/src/components/navigation_pages/Profile.tsx
@@ -295,11 +295,11 @@ const Profile: React.FC = () => {
             defaultValue="stories"
             className="relative w-[95%] md:w-[90%] xl:w-[85%] mx-auto mt-5 lg:mt-0 lg:mb-10 gap-0 lg:flex-grow"
           >
-            <TabsList className="p-0 absolute rounded-none rounded-t-lg grid grid-cols-2 bg-gray-300 z-10 h-10 shadow-none text-primary-text border border-b-0 border-primary-border">
+            <TabsList className="p-0 absolute rounded-none rounded-t-lg grid grid-cols-2 bg-gray-300 z-10 h-10 shadow-none text-primary-text border !border-b-0 border-primary-border">
               <TabsTrigger
                 value="stories"
                 className="data-[state=active]:shadow-none border-b data-[state=active]:border-r border-primary-border
- data-[state=active]:text-primary-text data-[state=active]:bg-white cursor-pointer rounded-none rounded-t-lg h-full w-full data-[state=active]:border-b-0"
+ data-[state=active]:text-primary-text data-[state=active]:bg-white cursor-pointer rounded-none rounded-t-lg h-full w-full data-[state=active]:!border-b-0"
               >
                 <div className="flex items-center">
                   <BookOpen className="mr-2" size={18} />
@@ -309,7 +309,7 @@ const Profile: React.FC = () => {
               <TabsTrigger
                 value="gamification"
                 className="data-[state=active]:shadow-none border-b data-[state=active]:border-l border-primary-border
- data-[state=active]:text-primary-text data-[state=active]:bg-white cursor-pointer rounded-none rounded-t-lg h-full w-full data-[state=active]:border-b-0"
+ data-[state=active]:text-primary-text data-[state=active]:bg-white cursor-pointer rounded-none rounded-t-lg h-full w-full data-[state=active]:!border-b-0 "
               >
                 <div className="flex items-center">
                   <Trophy className="mr-2" size={18} />

--- a/frontend/src/components/navigation_pages/Profile.tsx
+++ b/frontend/src/components/navigation_pages/Profile.tsx
@@ -102,7 +102,7 @@ const Profile: React.FC = () => {
       ) : (
         <div className=" mb-5 lg:flex lg:gap-2 lg:p-4 ">
           <section className="flex flex-col lg:h-150 w-[95%] md:w-[90%] lg:w-100 mx-auto bg-card rounded-lg border border-primary-border p-4">
-            <div className="ml-auto">
+            <div className="ml-auto ">
               <UserSettings userPreference={userPreference} />
             </div>
             <section className="flex space-y-5">

--- a/frontend/src/components/navigation_pages/Profile.tsx
+++ b/frontend/src/components/navigation_pages/Profile.tsx
@@ -64,8 +64,6 @@ const Profile: React.FC = () => {
         // Single API call to get all user data
         const userData = await getUserProfileData();
 
-        console.log(userData);
-
         // Process username
         const user = userData.username.split("@")[0];
         const username = user[0].toUpperCase() + user.substring(1);

--- a/frontend/src/components/navigation_pages/Profile.tsx
+++ b/frontend/src/components/navigation_pages/Profile.tsx
@@ -100,8 +100,8 @@ const Profile: React.FC = () => {
       {isLoading ? (
         <ProfileSkeleton />
       ) : (
-        <div className="h-full mb-5">
-          <section className="flex flex-col w-[95%] md:w-[90%] xl:w-[85%] mx-auto bg-card rounded-lg border border-primary-border p-4">
+        <div className=" mb-5 lg:flex lg:gap-2 lg:p-4 ">
+          <section className="flex flex-col lg:h-150 w-[95%] md:w-[90%] lg:w-100 mx-auto bg-card rounded-lg border border-primary-border p-4">
             <div className="ml-auto">
               <UserSettings userPreference={userPreference} />
             </div>
@@ -128,7 +128,7 @@ const Profile: React.FC = () => {
                       </div>
                     </div>
                   </AlertDialogTrigger>
-                  <AlertDialogContent>
+                  <AlertDialogContent className=" landscape:md:h-full landscape:lg:h-auto landscape:overflow-y-auto">
                     <AlertDialogHeader>
                       <AlertDialogTitle className="text-primary-text font-bold">
                         Select Profile Picture
@@ -273,12 +273,12 @@ const Profile: React.FC = () => {
             {!isEditing && (
               <Button
                 onClick={() => setIsEditing(!isEditing)}
-                className="self-center sm:self-start  mx-auto sm:mx-0 w-[90%] sm:w-[60%] mt-6 bg-gray-100 text-black border border-gray-300 hover:bg-gray-200 cursor-pointer"
+                className="self-center sm:self-start  mx-auto sm:mx-0 w-[90%] sm:w-[60%] md:w-[50%] lg:w-[90%] lg:self-center mt-6 bg-gray-100 text-black border border-gray-300 hover:bg-gray-200 cursor-pointer"
               >
                 Edit profile
               </Button>
             )}
-            <div className="self-center sm:self-start mx-auto sm:mx-0 w-[90%] sm:w-[60%] ">
+            <div className="self-center sm:self-start mx-auto sm:mx-0 w-[90%] sm:w-[60%] lg:w-full">
               {isEditing && (
                 <ProfileSettings
                   isEditing={isEditing}
@@ -293,7 +293,7 @@ const Profile: React.FC = () => {
           {/* Profile Content - Main Tabs */}
           <Tabs
             defaultValue="stories"
-            className="relative w-[95%] md:w-[90%] xl:w-[85%] mx-auto mt-5 gap-0"
+            className="relative w-[95%] md:w-[90%] xl:w-[85%] mx-auto mt-5 lg:mt-0 lg:mb-10 gap-0 lg:flex-grow"
           >
             <TabsList className="p-0 absolute rounded-none rounded-t-lg grid grid-cols-2 bg-gray-300 z-10 h-10 shadow-none text-primary-text border border-b-0 border-primary-border">
               <TabsTrigger
@@ -320,7 +320,7 @@ const Profile: React.FC = () => {
 
             {/* Your Stories Tab Content */}
             <TabsContent value="stories">
-              <section className="w-full space-y-8 bg-card p-8 mt-[39px] rounded-lg rounded-tl-none border border-primary-border">
+              <section className="w-full lg:min-h-full space-y-8 bg-card p-8 mt-[39px] rounded-lg rounded-tl-none border border-primary-border">
                 <section className="flex flex-col">
                   <div className="flex items-center text-secondary-text">
                     <BookOpen />

--- a/frontend/src/components/navigation_pages/Profile.tsx
+++ b/frontend/src/components/navigation_pages/Profile.tsx
@@ -21,6 +21,8 @@ import {
   AlertDialogTitle,
   AlertDialogTrigger,
 } from "@/components/ui/alert-dialog";
+import ProfileSettings from "../ProfileSettings";
+import UserSettings from "../UserSettings";
 
 const Profile: React.FC = () => {
   const { user } = useAuth();
@@ -46,6 +48,13 @@ const Profile: React.FC = () => {
     ProjectsData[] | null
   >([]);
   const [currentPage, setCurrentPage] = useState(0);
+
+  // maybe future add also private toggle
+  const [userPreference, setUserPreference] = useState<boolean>(false);
+
+  // state isEditing
+  const [isEditing, setIsEditing] = useState<boolean>(false);
+
   const ITEMS_PER_PAGE = 6;
 
   useEffect(() => {
@@ -68,6 +77,7 @@ const Profile: React.FC = () => {
         setProfilePictureOptions(userData.profilePictureOptions);
         setStoriesCompleted(userData.completedProjects);
         setStoriesInprogress(userData.inProgressProjects);
+        setUserPreference(userData.matureContentEnabled);
       } catch (error) {
         console.error("Error fetching profile data:", error);
       } finally {
@@ -93,8 +103,11 @@ const Profile: React.FC = () => {
         <ProfileSkeleton />
       ) : (
         <div className="h-full mb-5">
-          <section className="w-[95%] md:w-[90%] xl:w-[85%] mx-auto space-y-8 bg-card p-8 mt-5 rounded-lg border border-primary-border pb-4">
-            <section className="flex">
+          <section className="flex flex-col w-[95%] md:w-[90%] xl:w-[85%] mx-auto bg-card rounded-lg border border-primary-border p-4">
+            <div className="ml-auto">
+              <UserSettings userPreference={userPreference} />
+            </div>
+            <section className="flex space-y-5">
               <div>
                 <AlertDialog>
                   <AlertDialogTrigger asChild>
@@ -223,10 +236,14 @@ const Profile: React.FC = () => {
                   </AlertDialogContent>
                 </AlertDialog>
               </div>
-              <article>
-                <h3 className="text-2xl font-bold text-primary-text text-left mb-1 ml-3">
-                  {username}
-                </h3>
+
+              <article className="flex flex-col justify-center">
+                {!isEditing && (
+                  <h3 className="text-2xl font-bold text-primary-text text-left mb-1 ml-3">
+                    {username}
+                  </h3>
+                )}
+
                 {/* Completed Stories Tracker */}
                 <div className="flex items-center ml-3 text-secondary-text">
                   <BookOpen size={20} />
@@ -244,14 +261,35 @@ const Profile: React.FC = () => {
               </article>
             </section>
             {/* Bio */}
-            <section className="flex flex-col">
-              <h3 className="text-xl font-bold text-primary-text text-left mb-1 ml-3">
-                About Me
-              </h3>
-              <p className="ml-3 text-secondary-text text-left">
-                {bio.length > 0 ? bio : "No Bio Written"}
-              </p>
-            </section>
+            {!isEditing && (
+              <section className="flex flex-col">
+                <h3 className="text-xl font-bold text-primary-text text-left mb-1 ml-3">
+                  About Me
+                </h3>
+                <p className="ml-3 text-secondary-text text-left">
+                  {bio.length > 0 ? bio : "No Bio Written"}
+                </p>
+              </section>
+            )}
+
+            {!isEditing && (
+              <Button
+                onClick={() => setIsEditing(!isEditing)}
+                className="self-center sm:self-start  mx-auto sm:mx-0 w-[90%] sm:w-[60%] mt-6 bg-gray-100 text-black border border-gray-300 hover:bg-gray-200 cursor-pointer"
+              >
+                Edit profile
+              </Button>
+            )}
+            <div className="self-center sm:self-start mx-auto sm:mx-0 w-[90%] sm:w-[60%] ">
+              {isEditing && (
+                <ProfileSettings
+                  isEditing={isEditing}
+                  setIsEditing={setIsEditing}
+                  setBio={setBio}
+                  setUsername={setUsername}
+                />
+              )}
+            </div>
           </section>
 
           {/* Profile Content - Main Tabs */}

--- a/frontend/src/components/navigation_pages/ReadingPage.tsx
+++ b/frontend/src/components/navigation_pages/ReadingPage.tsx
@@ -34,6 +34,7 @@ import {
   Heart,
   Sparkles,
   Ghost,
+  ChevronLeft,
 } from "lucide-react";
 
 // Define reaction types
@@ -176,10 +177,11 @@ const ReadingPage: React.FC = () => {
       <div className="bg-white md:bg-background px-5">
         <Button
           variant="outline"
-          onClick={() => navigate("/stories")}
+          onClick={() => navigate(-1)} // go back where came from , so now if came from profile it will go back there
           className="text-sm bg-white md:bg-background"
         >
-          Back to Stories
+          <ChevronLeft />
+          <span>Back</span>
         </Button>
       </div>
       <Card className="border-none shadow-none md:shadow-lg">

--- a/frontend/src/components/routing/router.tsx
+++ b/frontend/src/components/routing/router.tsx
@@ -34,7 +34,7 @@ const Layout: React.FC<{ children: React.ReactNode }> = ({ children }) => {
             window.location.pathname.startsWith("/projects") ||
             window.location.pathname.startsWith("/sessions/create")
           ? "bg-white md:bg-background min-h-screen overflow-x-hidden"
-          : `min-h-screen overflow-x-hidden`
+          : `min-h-screen overflow-x-hidden lg:flex lg:flex-col`
       }
     >
       <Header loggedIn={isAuthenticated} page={window.location.pathname} />

--- a/frontend/src/components/user/RewardTrophiesPage.tsx
+++ b/frontend/src/components/user/RewardTrophiesPage.tsx
@@ -437,20 +437,20 @@ const RewardTrophiesPage: React.FC<RewardTrophiesPageProps> = ({ userId }) => {
           >
             {/* Desktop View: Normal Tabs */}
             <ScrollArea type="always">
-              <TabsList className="mb-4 overflow-x-auto flex-nowrap">
-                <TabsTrigger value="all">
+              <TabsList className="mb-4 overflow-x-auto flex-nowrap ">
+                <TabsTrigger value="all" className="cursor-pointer">
                   All ({unlockedCounts.all}/{achievements.length})
                 </TabsTrigger>
-                <TabsTrigger value="writing">
+                <TabsTrigger value="writing" className="cursor-pointer">
                   Writing ({unlockedCounts.writing}/
                   {achievements.filter((a) => a.category === "writing").length})
                 </TabsTrigger>
-                <TabsTrigger value="creation">
+                <TabsTrigger value="creation" className="cursor-pointer">
                   Creation ({unlockedCounts.creation}/
                   {achievements.filter((a) => a.category === "creation").length}
                   )
                 </TabsTrigger>
-                <TabsTrigger value="completion">
+                <TabsTrigger value="completion" className="cursor-pointer">
                   Completion ({unlockedCounts.completion}/
                   {
                     achievements.filter((a) => a.category === "completion")
@@ -458,11 +458,11 @@ const RewardTrophiesPage: React.FC<RewardTrophiesPageProps> = ({ userId }) => {
                   }
                   )
                 </TabsTrigger>
-                <TabsTrigger value="social">
+                <TabsTrigger value="social" className="cursor-pointer">
                   Social ({unlockedCounts.social}/
                   {achievements.filter((a) => a.category === "social").length})
                 </TabsTrigger>
-                <TabsTrigger value="special">
+                <TabsTrigger value="special" className="cursor-pointer">
                   Special ({unlockedCounts.special}/
                   {achievements.filter((a) => a.category === "special").length})
                 </TabsTrigger>

--- a/frontend/src/components/writing_pages/CreateSessionPage.tsx
+++ b/frontend/src/components/writing_pages/CreateSessionPage.tsx
@@ -35,6 +35,7 @@ import { FormData } from "@/types/global";
 
 // custom hook
 import useLocalStorage from "@/hooks/useLocalStorage";
+import { ChevronLeft } from "lucide-react";
 
 // Defines Project interface
 interface Project {
@@ -304,10 +305,11 @@ const CreateSession: React.FC = () => {
       <div className="px-5 bg-white md:bg-background">
         <Button
           variant="outline"
-          onClick={() => navigate("/sessions")}
+          onClick={() => navigate(-1)}
           className="text-sm bg-white md:bg-background"
         >
-          Back to Sessions
+          <ChevronLeft />
+          <span>Back</span>
         </Button>
       </div>
       <Card className="border-none shadow-none md:shadow-lg">

--- a/frontend/src/components/writing_pages/CreateSessionPage.tsx
+++ b/frontend/src/components/writing_pages/CreateSessionPage.tsx
@@ -202,21 +202,21 @@ const CreateSession: React.FC = () => {
       }
 
       // Check if content is flagged for moderation
-      const moderationResponse = await axios.post(
-        `${API_BASE_URL}/moderation`,
-        {
-          content: title + " " + description + " " + content,
-        }
-      );
+      // const moderationResponse = await axios.post(
+      //   `${API_BASE_URL}/moderation`,
+      //   {
+      //     content: title + " " + description + " " + content,
+      //   }
+      // );
 
-      // If content is flagged, display reason
-      if (moderationResponse.data.flagged) {
-        toast.error(
-          `Content flagged for ${moderationResponse.data.reason}. Please try again.`
-        );
-        setIsLoading(false);
-        return;
-      }
+      // // If content is flagged, display reason
+      // if (moderationResponse.data.flagged) {
+      //   toast.error(
+      //     `Content flagged for ${moderationResponse.data.reason}. Please try again.`
+      //   );
+      //   setIsLoading(false);
+      //   return;
+      // }
 
       const newProject: Project = {
         title,

--- a/frontend/src/components/writing_pages/WritingEditor.tsx
+++ b/frontend/src/components/writing_pages/WritingEditor.tsx
@@ -301,8 +301,6 @@ const WritingEditor: React.FC = () => {
 
         // If locked for more than 10 minutes, force unlock it
         if (timeDiffMinutes >= 10) {
-          console.log("Found stale lock on project, unlocking...");
-
           const { error: unlockError } = await supabase
             .from("projects")
             .update({
@@ -562,9 +560,6 @@ const WritingEditor: React.FC = () => {
     }
   };
 
-  console.log(previousSnippets.length);
-  console.log(project?.max_snippets);
-
   // Modify handleSubmit to reset timer and unlock project on successful submission
   const handleSubmit = async () => {
     if (wordCount < 50 || wordCount > 100) {
@@ -645,8 +640,6 @@ const WritingEditor: React.FC = () => {
         }
 
         // check if the submitted snippet is the max amount of snippets if so then mark project as completed
-        console.log(previousSnippets.length);
-        console.log(project?.max_snippets);
 
         const { error: updateCountError } = await supabase
           .from("projects")
@@ -875,8 +868,6 @@ const WritingEditor: React.FC = () => {
                 locked_at: null,
               })
               .eq("id", projectId);
-
-            console.log("Project unlocked on component unmount");
           } catch (error) {
             console.error("Error unlocking project on unmount:", error);
           }

--- a/frontend/src/components/writing_pages/WritingEditor.tsx
+++ b/frontend/src/components/writing_pages/WritingEditor.tsx
@@ -107,7 +107,6 @@ const WritingEditor: React.FC = () => {
   const localStorageKey = `draftText_${user?.id}_${projectId}`;
   const [content, setContent] = useLocalStorage(localStorageKey, "");
 
-
   console.log(isContributor);
 
   // Function to fetch contributors - simplified version
@@ -563,6 +562,9 @@ const WritingEditor: React.FC = () => {
     }
   };
 
+  console.log(previousSnippets.length);
+  console.log(project?.max_snippets);
+
   // Modify handleSubmit to reset timer and unlock project on successful submission
   const handleSubmit = async () => {
     if (wordCount < 50 || wordCount > 100) {
@@ -577,21 +579,21 @@ const WritingEditor: React.FC = () => {
       }
       setIsSubmitting(true);
 
-      const moderationResponse = await axios.post(
-        `${API_BASE_URL}/moderation`,
-        {
-          content: content,
-        }
-      );
+      // const moderationResponse = await axios.post(
+      //   `${API_BASE_URL}/moderation`,
+      //   {
+      //     content: content,
+      //   }
+      // );
 
-      // If content is flagged, display reason
-      if (moderationResponse.data.flagged) {
-        toast.error(
-          `Content flagged for ${moderationResponse.data.reason}. Please try again.`
-        );
-        setIsSubmitting(false);
-        return;
-      }
+      // // If content is flagged, display reason
+      // if (moderationResponse.data.flagged) {
+      //   toast.error(
+      //     `Content flagged for ${moderationResponse.data.reason}. Please try again.`
+      //   );
+      //   setIsSubmitting(false);
+      //   return;
+      // }
 
       // Add the snippet
       const { error: snippetError } = await supabase
@@ -642,6 +644,10 @@ const WritingEditor: React.FC = () => {
           console.error("Error adding new contributor:", contributorError);
         }
 
+        // check if the submitted snippet is the max amount of snippets if so then mark project as completed
+        console.log(previousSnippets.length);
+        console.log(project?.max_snippets);
+
         const { error: updateCountError } = await supabase
           .from("projects")
           .update({
@@ -658,7 +664,7 @@ const WritingEditor: React.FC = () => {
         }
         setIsContributor(true);
       } else {
-        // updatges contribution time for existing contributor
+        // updates contribution time for existing contributor
         const { error: updateError } = await supabase
           .from("project_contributors")
           .update({

--- a/frontend/src/components/writing_pages/WritingEditor.tsx
+++ b/frontend/src/components/writing_pages/WritingEditor.tsx
@@ -15,7 +15,7 @@ import { Button } from "@/components/ui/button";
 import { Textarea } from "@/components/ui/textarea";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 
-import { Crown, Loader2, Lightbulb, Clock } from "lucide-react";
+import { Crown, Loader2, Lightbulb, Clock, ChevronLeft } from "lucide-react";
 import {
   supabase,
   getCurrentUser,
@@ -856,7 +856,7 @@ const WritingEditor: React.FC = () => {
     if (isCurrentlyWriting && lockedBy === userData?.auth_id) {
       await handleCancelWriting();
     }
-    navigate("/sessions");
+    navigate(-1);
   };
 
   // Add a cleanup effect to unlock the project when the component unmounts
@@ -895,7 +895,8 @@ const WritingEditor: React.FC = () => {
           onClick={handleBackClick}
           className="text-sm bg-white md:bg-background"
         >
-          Back to Sessions
+          <ChevronLeft />
+          <span>Back</span>
         </Button>
       </div>
       <Card className="border-none shadow-none md:shadow-lg">

--- a/frontend/src/utils/formSchemas.ts
+++ b/frontend/src/utils/formSchemas.ts
@@ -26,7 +26,6 @@ const loginSchema = z.object({
 const settingsSchema = z.object({
   username: z.string(),
   bio: z.string().max(180, { message: "Bio must be less than 180 characters" }),
-  matureContent: z.boolean(),
 });
 
 export { registerSchema, loginSchema, settingsSchema };


### PR DESCRIPTION
Combined Profile and Settings, changed layout of desktop view. (awkward amount of space)
cog wheel for just the users settings and deletion
and the username and bio under the profile picture

header + header mobile sheet , settings nav is gone
profile cards now go to proper page, before bug where the sessions cards will bring them to a reading view and not the writing page of the session card.

add missing cursor pointers

made OpenSessionPage and StoriesPage have their cards clickable

changed the back button, to just go back 1 step, as this makes it so if user came from the profile cards it would go back to profile and not just sessions